### PR TITLE
Changed Varnish Configs

### DIFF
--- a/varnish.default.vcl
+++ b/varnish.default.vcl
@@ -8,19 +8,26 @@ backend default {
 sub vcl_recv {
     if (req.url ~ "^/sitestatic/") {
         return (hash);
-    } else {
+    } else if (req.url ~ "^/api/") {
         return (pipe);
+    } else {
+        return (pass);
     }
 }
 
 sub vcl_backend_response {
     if (bereq.url ~ "^/sitestatic/") {
-        set beresp.http.Expires = now + 43200s;
-	    set beresp.ttl = 720m;
+        set beresp.ttl = 120m;
+    } else {
+        set beresp.uncacheable = true;
     }
 }
 
 sub vcl_deliver {
     unset resp.http.Via;
     unset resp.http.Server;
+}
+
+sub vcl_pipe {
+    set bereq.http.connection = "close";
 }


### PR DESCRIPTION
**Pass**: Pass mode is very common in Varnish, and just tells Varnish to pass the request to the backend rather than try and serve it from cache. This is used for dynamic pages that should not be cached. 

**Pipe**: Pipe mode is quite different and is rarely used. If you want to stream objects, such as videos, you'll want to use pipe to avoid timeouts. Using pipe means Varnish stops inspecting each request, and just sends bytes straight to the backend. There are multiple gotchas when using pipe, so be sure to checkout using pipe in the Varnish docs.